### PR TITLE
TCA - Add other Platforms. (macOS, watchOS, tvOS)

### DIFF
--- a/Templates/File Templates/TheComposableArchitecture/TCA.xctemplate/TemplateInfo.plist
+++ b/Templates/File Templates/TheComposableArchitecture/TCA.xctemplate/TemplateInfo.plist
@@ -64,6 +64,9 @@
 	<key>Platforms</key>
 	<array>
 		<string>com.apple.platform.iphoneos</string>
+		<string>com.apple.platform.macosx</string>
+		<string>com.apple.platform.watchos</string>
+		<string>com.apple.platform.appletvos</string>
 	</array>
 	<key>SortOrder</key>
 	<string>2</string>


### PR DESCRIPTION
Hello. 👋

Added **macOS, watchOS, and tvOS** to the Platforms section of the TCA Template.
Since the official README for the TCA states that it **supports all Apple platforms,** we believe this modification makes sense.

> It can be used in SwiftUI, UIKit, and more, and on any Apple platform (iOS, macOS, tvOS, and watchOS).
> [README of TCA](https://github.com/pointfreeco/swift-composable-architecture#the-composable-architecture)

---

TCA Template의 Platforms 항목에 **macOS, watchOS, tvOS**를 추가하였습니다.
TCA의 공식 README 에 **모든 Apple Platform을 지원**한다고 명시되어 있으므로, 이 수정은 타당하다고 생각합니다.